### PR TITLE
Add onWatch — open-source AI API quota tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [onWatch](https://github.com/onllm-dev/onwatch): Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, and more) with a background daemon, <50MB RAM, and zero telemetry.
 
 ## Datasets
 


### PR DESCRIPTION
Adds [onWatch](https://github.com/onllm-dev/onwatch) to the Projects section.

**onWatch** is an open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, Synthetic, Z.ai, MiniMax, and Antigravity). It runs as a background daemon with <50MB RAM, stores data locally in SQLite with zero telemetry, and includes a Material Design 3 web dashboard. Works with Cline, Roo Code, Kilo Code, Claude Code, Codex CLI, Cursor, and GitHub Copilot.

- 342+ GitHub stars, GPL-3.0 license
- Single ~13MB Go binary, cross-platform (macOS, Linux, Windows)
- Docker support (distroless image, ~10MB)