### PR TITLE
Add claw-army/claude-node - Python subprocess bridge for Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [claw-army/claude-node](https://github.com/claw-army/claude-node): Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
 
 ## Datasets
 


### PR DESCRIPTION
Add claude-node to the list.