### PR TITLE
Add claude-node - Python library for Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A list of AI coding topics.
 - [Autodoc](https://github.com/context-labs/autodoc): Generate codebase documentation use LLM (OpenAI / Alpaca)
 - [CodeAlpaca](https://github.com/sahil280114/codealpaca): LLaMA trained on code instruction following.
 - [🐾 Tabby](https://github.com/TabbyML/tabby): An opensource / on-prem alternative to GitHub Copilot.
+- [claude-node](https://github.com/claw-army/claude-node): Python library that drives the local Claude Code CLI as a long-lived subprocess via stream-json for persistent AI assistant sessions.
 - [promptr](https://github.com/ferrislucas/promptr): CLI tool to operating on your codebase using GPT.
 - [ChatIDE](https://github.com/yagil/ChatIDE): Extension let you talk to ChatGPT inside VSCode.
 - [PromptMate](https://github.com/MateusZitelli/PromptMate): VSCode extension embed ChatGPT.


### PR DESCRIPTION
## Add claude-node

Python library that drives the local Claude Code CLI as a long-lived subprocess via stream-json for persistent AI assistant sessions.

- GitHub: https://github.com/claw-army/claude-node
- Stars: 7

Please review and merge if appropriate.