### PR TITLE
Add Don Cheli — SDD Framework for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [Don Cheli](https://github.com/doncheli/don-cheli-sdd): Specification-Driven Development framework for Claude Code — 72+ commands, 43 skills, 15 reasoning models, TDD as iron law, OWASP security audit, and 6 quality gates. Multilingual (ES/EN/PT).
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
## What is Don Cheli?

[Don Cheli](https://github.com/doncheli/don-cheli-sdd) is the most comprehensive Specification-Driven Development (SDD) framework for Claude Code and other AI coding agents.

**Key stats:** 72+ commands, 43 skills, 15 reasoning models, 4 estimation models, 6 quality gates, TDD as iron law, OWASP security audit, multilingual (ES/EN/PT). Apache 2.0. Published on npm as `don-cheli-sdd`.

**Why it belongs here:** Open-source AI coding tool that transforms "vibe coding" into structured, verifiable software engineering.