### PR TITLE
Add Cortex - AI Memory Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Cortex](https://github.com/SKULLFIRE07/cortex-memory): Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context from Claude Code, Cursor, and Cline sessions. 3-layer memory. VSCode extension + CLI + MCP server. Free.
 
 ## Datasets
 


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed