### PR TITLE
Add IM.codes - The IM for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [IM.codes](https://github.com/im4codes/imcodes): Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents, built for away-from-desk continuation with terminal access, file browsing, git views, localhost preview, notifications, scheduled tasks / cron jobs, and multi-agent workflows.
 
 ## Datasets
 


### PR DESCRIPTION
Add IM.codes under **Projects**.

IM.codes is a mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents. The main differentiator is away-from-desk continuation: it keeps long-running agent workflows within reach from phone or browser with terminal access, file browsing, git views, localhost preview, notifications, scheduled tasks / cron jobs, and multi-agent workflows.

Repo: https://github.com/im4codes/imcodes