### PR TITLE
Add Ptah - multi-provider AI coding orchestra

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [Ptah](https://github.com/Hive-Academy/ptah-extension): Multi-provider AI coding orchestra (VS Code + Electron). Connects to OpenRouter, Kimi, GLM, Copilot, Gemini, and Codex from one interface with CLI agent orchestration, built-in MCP server, and plugin ecosystem. Open source (FSL-1.1-MIT).
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
## New Tool Information
- **Tool Name:** Ptah - The Coding Orchestra
- - **Description:** Multi-provider AI coding orchestra for VS Code and desktop that connects to OpenRouter (200+ models), Kimi, GLM, Copilot, Gemini, and Codex from one interface with CLI agent orchestration, MCP server, and plugin ecosystem.
- - **Tool URL:** https://github.com/Hive-Academy/ptah-extension
- - **Altern.ai page link:** N/A
## Description

Added [Ptah](https://github.com/Hive-Academy/ptah-extension) to the **Developer tools** section.

Ptah is an open-source AI coding tool available as a VS Code extension and standalone Electron desktop app. It connects to multiple AI providers from one unified interface:

- **Multi-provider support**: OpenRouter (200+ models), Moonshot/Kimi (K2, K2.5), Z.AI/GLM (including free models), GitHub Copilot, Gemini CLI, OpenAI Codex, and direct Anthropic API
- - **CLI agent orchestration**: Spawn background AI agents from different providers and manage them via 6 MCP lifecycle tools (spawn, status, read, steer, stop, list)
- - **Built-in MCP server**: 14 API namespaces for workspace intelligence — semantic file search, tree-sitter AST analysis, diagnostics, dependency graphs, git operations
- - **Plugin ecosystem**: 4 plugin packs with 19+ skills (orchestration workflows, code review, Angular, NestJS, React patterns)
- - **Workspace intelligence**: Setup wizard scans your codebase and tailors AI interactions to your specific stack
Open source under FSL-1.1-MIT license.

- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=ptah-extensions.ptah-coding-orchestra
- - Website: https://ptah.live
---

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] - [x] **Only one tool is modified in this PR**
- [ ] - [x] All required fields (name, description, URL, altern.ai link if available) are provided
- [ ] - [x] The tool link is **valid** and accessible
- [ ] - [x] The tool is **not already listed**