### PR TITLE
Add toprank to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [toprank](https://github.com/nowork-studio/toprank): Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, rewrite meta tags, generate JSON-LD schema, and ship fixes to WordPress/Strapi/Contentful/Ghost. 107 stars, 14 forks.
 
 ## Datasets
 


### PR DESCRIPTION
Adds **toprank** to the Projects section.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It gives Claude Code direct access to Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes (meta tags, JSON-LD schema, keyword bids, content pushes to WordPress/Strapi/Contentful/Ghost) directly from the terminal.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank