### PR TITLE
Add Skills-Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Skills-Link](https://github.com/shanliuling/skills-link): A CLI tool that syncs your AI skills across 41+ coding agents (Claude Code, Cursor, Windsurf, Cline, etc.) with cross-device sync via GitHub.
 
 ## Datasets
 


### PR DESCRIPTION
Add [Skills-Link](https://github.com/shanliuling/skills-link) to the Projects section.

Skills-Link is a CLI tool that syncs your AI skills across 41+ coding agents (Claude Code, Cursor, Windsurf, Cline, etc.) with cross-device sync via GitHub.