### PR TITLE
Add KubeStellar Console to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A list of AI coding topics.
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
 
+- [KubeStellar Console](https://github.com/kubestellar/console): Multi-cluster Kubernetes dashboard with AI-powered operations. Uses CLAUDE.md and MCP protocol to let AI agents manage Kubernetes clusters.
+
 ## Datasets
 
 - [The Pile](https://huggingface.co/datasets/the_pile)


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Projects** section.

**KubeStellar Console** is an open-source, multi-cluster Kubernetes dashboard with AI-powered operations. It uses **CLAUDE.md** and the **MCP protocol** to let AI coding agents (Claude Code, Copilot, Cursor) manage Kubernetes clusters directly.

Part of the [KubeStellar](https://kubestellar.io) CNCF Sandbox project.

- AI/LLM integration for Kubernetes operations via MCP
- CLAUDE.md file for AI agent guidance  
- Multi-cluster management across edge and cloud
- Integrates with 20+ CNCF projects