### PR TITLE
Add Onepilot to Products & Startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [Onepilot](https://onepilotapp.com): iOS and iPadOS SSH client for running Claude Code, Codex CLI, and other terminal coding agents on a remote machine.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
Adding Onepilot to the Products & Startups section.

Onepilot is an iOS and iPadOS SSH client for running terminal coding agents (Claude Code, Codex CLI, and others) on a remote machine. https://onepilotapp.com

Entry appended at the end of the section, matching the existing format.