### PR TITLE
Add Parallel Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Parallel Code](https://github.com/johannesjo/parallel-code): Open-source desktop app for running multiple CLI coding agents in parallel, with isolated git worktrees, terminal panes, diff review, and merge controls.
 
 ## Datasets
 


### PR DESCRIPTION
Adds Parallel Code to the projects section.

Parallel Code is a free, MIT-licensed desktop app for running terminal-based coding agents such as Claude Code, Codex CLI, and Gemini CLI in parallel. Each task runs in its own Git branch and worktree, with terminal panes, diff review, and merge controls.