### PR TITLE
Add ejentum-mcp under Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp): MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
 
 ## Datasets
 


### PR DESCRIPTION
Adds `ejentum-mcp` under **Projects**, after `Arctic` (matching the section's add-order convention).

stdio MCP server (npm `ejentum-mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained, listed on Official MCP Registry as `io.github.ejentum/ejentum-mcp`
- One line added under Projects
- Not a duplicate

Maintainer is me; happy to address review feedback.