### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [codex-profiles](https://github.com/Ducksss/codex-profiles): Bash helper for switching OpenAI Codex CLI/Desktop accounts via isolated `CODEX_HOME` profiles without copying tokens.
 
 ## Datasets
 


### PR DESCRIPTION
## Summary

Adds `codex-profiles`, a small open-source helper for switching Codex CLI and Codex Desktop accounts with isolated `CODEX_HOME` profiles.

## Why

This list collects AI coding projects and workflow utilities. codex-profiles directly supports OpenAI Codex CLI/Desktop workflows by keeping account state, config, sessions, and logs isolated without copying auth files.

## Validation

- Ran `git diff --check`
