### PR TITLE
Add Everything OpenAI Codex to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [ecc (Everything Codex)](https://github.com/mturac/everything-openai-codex): Cross-harness workflow system with 230+ skills, 60 agents, quality gates, and session memory — works across Codex, Cursor, Gemini CLI, Copilot, and more.
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
-- [ecc (Everything Codex)](https://github.com/mturac/everything-openai-codex): Cross-harness workflow system with 230+ skills, 60 agents, quality gates, and session memory — works across Codex, Cursor, Gemini CLI, Copilot, and more.
+- [eoc (Everything OpenAI Codex)](https://github.com/mturac/everything-openai-codex): Cross-harness workflow system with 230+ skills, 60 agents, quality gates, and session memory — works across Codex, Cursor, Gemini CLI, Copilot, and more.
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
-- [eoc (Everything OpenAI Codex)](https://github.com/mturac/everything-openai-codex): Cross-harness workflow system with 230+ skills, 60 agents, quality gates, and session memory — works across Codex, Cursor, Gemini CLI, Copilot, and more.
+- [Everything OpenAI Codex](https://github.com/mturac/everything-openai-codex): MIT-licensed OpenAI Codex workflow system with agents, skills, commands, hooks, install profiles, validation checks, and session memory for repeatable coding work.
 
 ## Datasets
 


### PR DESCRIPTION
Adds [Everything OpenAI Codex](https://github.com/mturac/everything-openai-codex) to the Projects section. EOC is an MIT-licensed OpenAI Codex workflow system with agents, skills, commands, hooks, install profiles, validation checks, and session memory for repeatable coding work.