### PR TITLE
Add usage menu bar quota tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [usage](https://github.com/aqua5230/usage): macOS menu bar tracker for Claude Code and Codex quota, tokens, and cost. Reads local statusLine hook output and session JSONL files — zero Anthropic/OpenAI API calls. HTML reports and 9 visual themes. AGPL-3.0.
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
-- [usage](https://github.com/aqua5230/usage): macOS menu bar tracker for Claude Code and Codex quota, tokens, and cost. Reads local statusLine hook output and session JSONL files — zero Anthropic/OpenAI API calls. HTML reports and 9 visual themes. AGPL-3.0.
+- [usage](https://github.com/aqua5230/usage): macOS menu bar and Windows tray tracker for Claude Code, Codex, and Antigravity quota, tokens, and cost. Claude Code and Codex read local statusLine hook output and session JSONL files — no LLM API calls. HTML reports and 9 visual themes. AGPL-3.0.
 
 ## Datasets
 


### PR DESCRIPTION
Adding [usage](https://github.com/aqua5230/usage) to Projects — a macOS menu bar tracker for Claude Code and Codex quota / tokens / cost.

Sits well alongside [Arctic](https://github.com/arctic-cli/interface), which also targets multi-agent quota visibility but does it in a TUI. usage is the always-visible menu-bar counterpart.

- macOS menu bar app with expandable popover (5h / 7d quota, per-project usage, daily tokens, cost)
- Reads `~/.claude/usage-status.json` (written by an installed statusLine hook) and `~/.codex/sessions/*.jsonl` — zero API calls to Anthropic or OpenAI
- HTML report exporter, 9 visual themes, 5-language i18n
- AGPL-3.0, Homebrew install