### PR TITLE
feat: add TWZRD Agent Intel — Solana agent trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz): Trust scoring and identity verification for AI agents on Solana. Free MCP server with `score_agent` and `preflight_check` tools — verify agent wallet identity before x402 micropayments.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Products & Startups** section.

TWZRD Agent Intel is a trust scoring and identity verification service for AI agents operating with x402 micropayments on Solana. It exposes a free MCP server so any AI coding agent can verify another agent's wallet identity before initiating paid tool calls.

**Free MCP config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Tools:** `score_agent(wallet)`, `preflight_check(wallet)` (free), `get_trust_receipt(wallet)` (paid, ~$0.001 x402)