### PR TITLE
Add Cate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Cate](https://github.com/0-AI-UG/cate): Open source IDE on an infinite zoomable canvas. Arrange editors, terminals, browsers, and Claude Code agent panels in spatial workspaces instead of tabs.
 
 ## Datasets
 


### PR DESCRIPTION
Adds Cate to the Projects section. Cate is an open source desktop IDE (Electron + React + TypeScript, MIT) built on an infinite canvas. It hosts Monaco editors, xterm.js terminals, embedded browsers, and AI agent panels backed by Claude Code, so it fits alongside the other open source AI coding tools listed here.
