### PR TITLE
Add ax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [ax](https://github.com/Necmttn/ax): Telemetry + recall for coding agents.
 
 ## Datasets
 


### PR DESCRIPTION
Adds ax to the Projects section.

Checks:
- git diff --check
- curl -L https://github.com/Necmttn/ax -> 200
- markdownlint baseline unchanged: 50 errors before and after
- awesome-lint has existing baseline failures; this entry follows the repo's colon format, which awesome-lint flags like the existing entries

---

_Generated with [ax](https://github.com/Necmttn/ax)._