### PR TITLE
Add LoopTroop to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop): Local, open-source GUI that orchestrates AI coding agents from ticket to PR, with LLM-council planning, isolated git worktrees, and a Ralph loop that retries on failure. Built on OpenCode.
 
 ## Datasets
 


### PR DESCRIPTION
I added LoopTroop under Projects.

It's a local, open-source GUI I've been building that orchestrates AI coding agents from a ticket through to a reviewable PR. An LLM council plans the work, tasks run in isolated git worktrees, and a Ralph loop resets the worktree and retries from clean context when a run goes wrong. It's built on OpenCode.

Felt like a fit alongside the other open-source tools in the section like Tabby and PraisonAI. One entry at the end, matching the existing format.

Repo: https://github.com/looptroop-ai/LoopTroop