### PR TITLE
Add agent-harness to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [agent-harness](https://github.com/uzysjung/uzys-agent-harness): One-command installer & curator of vetted AI-coding skills, plugins, rules, and hooks by tech stack across Claude Code (first-class), Codex, OpenCode, and Antigravity. Trust-tier curated (≥1000★ + Docker install-verification), project-scoped by default.
 
 ## Datasets
 


### PR DESCRIPTION
Adds **agent-harness** to Projects — a CLI that curates and installs vetted AI-coding skills, plugins, rules, and hooks by tech stack across Claude Code (first-class), Codex, OpenCode, and Antigravity. MIT, project-scoped by default, `npx @uzysjung/agent-harness`. Matches the existing one-line `[name](url): desc.` style.