### PR TITLE
Add VibeKit.bot to Products & Startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [VibeKit.bot](https://vibekit.bot): Hosted AI coding agents you drive from your phone — each app gets its own persistent agent that builds, hosts, and keeps improving it (database + live domain included). BYOK (Claude/OpenAI) or pay-as-you-go.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
Adds **VibeKit.bot** to the Products & Startups section.

VibeKit is a hosted AI-coding product: each app gets its own persistent AI coding agent that builds, hosts, and keeps improving it (database + live domain included), driven from your phone, the web, or CLI — BYOK (Claude/OpenAI) or pay-as-you-go. It fits alongside the other AI-coding products in the section (Replit Ghostwrite, Cursor, Taskade Genesis, etc.).

Listed as **VibeKit.bot** → https://vibekit.bot to disambiguate from the unrelated `superagent-ai/vibekit` SDK. Format-matched to the existing `[Name](url): description` entries; appended after the most recent addition. Thanks for maintaining the list!