### PR TITLE
Add Quota Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.
 
 ## Datasets
 


### PR DESCRIPTION
Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser; tokens never leave the user's machine.

- Live demo (mock mode, no credentials): https://ryan-knowone.github.io/quota-dashboard/?mock=1
- Repo: https://github.com/ryan-knowone/quota-dashboard

Proposed entry under Projects:
- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.