### PR TITLE
Add DevIntern to Products & Startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [DevIntern](https://devintern.com/): Tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, and others), running on your machines with your own model keys.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
Adds [DevIntern](https://devintern.com/) to the Products & Startups section.

DevIntern picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), running on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions, and an optional unattended mode schedules ticket pickup and turns PR review comments into commits.

Repo: https://github.com/getdevintern/devintern (FSL-1.1 source-available, free for interactive use). Docs: https://devintern.com/docs

Entry matches the existing format and is appended at the end of the section.