### PR TITLE
Add ctx-optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [ctx-optimize](https://github.com/muthuishere/ctx-optimize): Deterministic code knowledge-graph CLI; a single Go binary indexes a repo with tree-sitter so a coding agent can query symbols, callers, callees, and change impact instead of grep-and-read. No LLM at query time.
 
 ## Datasets
 


### PR DESCRIPTION
Adds ctx-optimize under Projects. It is an open-source deterministic code knowledge-graph CLI that indexes a repo with tree-sitter so a coding agent can query symbols, callers, callees, and change impact instead of grep-and-read. It fits alongside the other open-source AI coding projects listed there.

Repo: https://github.com/muthuishere/ctx-optimize