### PR TITLE
Add Relay to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Relay](https://github.com/dbisina/relay): Vendor-neutral orchestrator that hands a coding task off between Claude Code, Codex, Copilot, Cursor, Cline, Continue, Antigravity, and OpenCode when the active one hits its usage limit, using a signed continuation contract so intent, plan, and in-flight code survive the switch.
 
 ## Datasets
 


### PR DESCRIPTION
Adds [Relay](https://github.com/dbisina/relay), a vendor-neutral orchestrator that keeps a coding task moving across Claude Code, Codex, Copilot, Cursor, Cline, Continue, Antigravity, and OpenCode by handing it off via a signed continuation contract when the active agent hits its usage limit. Apache-2.0, active development.