### PR TITLE
Add Codex Skin Pack Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs/tree/main/codex-skin-pack-installer): Codex Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance.
 
 ## Datasets
 


### PR DESCRIPTION
Adds Codex Skin Pack Installer to the Projects section.\n\nWhy it fits:\n- It is a Codex Skill for AI coding users who customize their Codex Desktop workspace.\n- It stages verified skin packs from GitHub releases, validates files, and keeps restore guidance so users can revert safely.\n- The linked repository includes the Skill, public-safe skin packs, release downloads, and install notes.