### PR TITLE
Add Ordewell to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Ordewell](https://github.com/ordewell/ordewell): open-source CLI/TUI that turns one goal into an ordered plan of coding-agent tasks (Claude Code, Codex, OpenCode) — each task with its own runner, model and mode.
 
 ## Datasets
 


### PR DESCRIPTION
Adds Ordewell — an open-source CLI/TUI that turns one goal into an ordered plan of coding-agent tasks (Claude Code, Codex, OpenCode) — to the Projects section.