### PR TITLE
Add SigRank — AI coding operator leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [SigRank](https://github.com/SunrisesIllNeverSee/sigrank-app): A privacy-preserving leaderboard that ranks AI coding operators by token cascade efficiency (Yield). [signalaf.com](https://signalaf.com)
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
-- [SigRank](https://github.com/SunrisesIllNeverSee/sigrank-app): A privacy-preserving leaderboard that ranks AI coding operators by token cascade efficiency (Yield). [signalaf.com](https://signalaf.com)
+- [SigRank](https://github.com/SunrisesIllNeverSee/sigrank-app): AI stats, evals, & leaderboard for operators NOT models. [signalaf.com](https://signalaf.com)
 
 ## Datasets
 


### PR DESCRIPTION
## What is SigRank?

SigRank is a privacy-preserving leaderboard that ranks AI coding operators by token cascade efficiency (Yield), not raw token volume. The core metric:

    Υ = (cache_read × output) / input²

It reads local AI session logs (Claude Code, Cursor, etc.), extracts four token pillars (input, output, cache_creation, cache_read), computes the cascade, and publishes to a public leaderboard at [signalaf.com](https://signalaf.com) — token counts only, never prompt content.

- **Live:** signalaf.com
- **CLI:** `npx sigrank` (no install, no sign-in)
- **npm:** 5,198 downloads/month
- **GitHub:** SunrisesIllNeverSee/sigrank-app
- **MCP server:** SunrisesIllNeverSee/sigrank-mcp

## Where I added it

Appended to the **Projects** section, after Arctic (the last entry).

## Why it fits

awesome-ai-coding lists AI coding tools and projects. SigRank is the first operator-level analytics and ranking platform for AI coding — it measures the humans using the tools, not the tools themselves. Complements the existing list which focuses on code generation and completion tools.