### PR TITLE
Add Atomic Agent to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine via a llama.cpp fork, with 56 built-in tools and MCP support; no account or API key required. Currently a developer preview, so commands and config are still moving.
 
 ## Datasets
 


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for keeping this list going, our team would be thrilled if you added us.

Adds [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) to the Projects section.

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so there is no account or API key needed to install and run it. The TUI is built on React and ink. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. Works on macOS, Linux, and Windows.

Being upfront: it is a developer preview, so APIs, commands, config, and behavior are still moving. I mentioned that in the row itself rather than leaving it out. The project is about four months old, but active (~2k stars, MIT licensed) and maintained by the AtomicBot-ai organization, which ships several established projects.

- Repo: https://github.com/AtomicBot-ai/atomic-agent
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Discord: https://discord.gg/Us7qXtDGw
- X: https://x.com/atomicagent_io

Happy to adjust the wording or move the entry if you would prefer it somewhere else.
