### PR TITLE
Add claude-carbon (carbon footprint tracking for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A list of AI coding topics.
 - [batchai](https://github.com/qiangyt/batchai): A supplement to Copilot and Cursor - utilizes AI for batch processing of project codes
 - [Berrry](https://berrry.app): AI-powered platform that transforms social media posts into functional web applications using LLM code generation.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [claude-carbon](https://github.com/gwittebolle/claude-carbon): Track the carbon footprint of your Claude Code sessions with a live status line, reports, and shareable cards.
 
 ## Datasets
 


### PR DESCRIPTION
Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon), an MIT-licensed tool that tracks the CO2 footprint of Claude Code sessions: live estimate in the status line, per-model session reports, and shareable PNG report cards (EN/FR). 160+ stars, actively maintained since April 2026, methodology publicly documented. I'm the author.
