### PR TITLE
Add SandBase CLI to AI coding projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A list of AI coding topics.
 
 ## Projects
 
+- [SandBase CLI](https://github.com/sandbaseai/cli): An open-source terminal CLI and MCP bridge for accessing 2,000+ AI models through a unified interface, with support for coding workflows and agent tools.
 - [BigCode](https://github.com/bigcode-project): open scientific collaboration run by Hugging Face.
 - [Fauxpilot](https://github.com/fauxpilot/fauxpilot): Code completion server with *CodeGen*.
 - [CodeGPT.nvim](https://github.com/dpayne/CodeGPT.nvim): ChatGPT in neovim.


### PR DESCRIPTION
## Summary
- add SandBase CLI to the Projects section
- link to the canonical repository and describe its unified MCP/CLI workflow

SandBase CLI is an open-source terminal CLI and MCP bridge for accessing 2,000+ AI models through one interface. The entry is based on the project README and keeps the list's existing concise format.
