### PR TITLE
Add Speak AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [Speak AI](https://speakai.co): AI-native sales acceleration platform that scores calls, meetings, and role plays against your own methodology and turns them into coaching notes and CRM updates, with a public API and 107-tool MCP server for Claude, Cursor, and ChatGPT.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
Speak AI is an AI-native sales acceleration platform that scores calls and meetings against your own methodology and exposes that via a public API and MCP server for coding agents like Claude, Cursor, and ChatGPT.
https://speakai.co