### PR TITLE
Add ContextStream to Products and Startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ AI-assisted Code Authoring](https://arxiv.org/abs/2305.12050)
 - [Trae](https://www.trae.ai/home)
 - [Taskade Genesis](https://taskade.com/genesis): AI-powered platform for building custom AI agents, workflows, and apps using natural language.
 - [OpenPaw](https://github.com/daxaur/openpaw): Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.
+- [ContextStream](https://contextstream.io): Shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is. Benchmarks: https://contextstream.io/benchmarks.
 
 ## Peer Awesome Lists
 - [Awesome AI-Powered Developer Tools](https://github.com/jamesmurdza/awesome-ai-devtools)


### PR DESCRIPTION
## Summary

Adds [ContextStream](https://contextstream.io) to Products & Startups.

ContextStream is shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- Remote MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks

Disclosure: I work on ContextStream.